### PR TITLE
Add support for ingesting the Area file

### DIFF
--- a/EconDataLens.Core/Configuration/BlsOptions.cs
+++ b/EconDataLens.Core/Configuration/BlsOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace EconDataLens.Core.Configuration;
+
+public class BlsOptions
+{
+    public CpiOptions Cpi { get; set; } = new CpiOptions();
+}

--- a/EconDataLens.Core/Configuration/CpiOptions.cs
+++ b/EconDataLens.Core/Configuration/CpiOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace EconDataLens.Core.Configuration;
+
+public class CpiOptions
+{
+    public string BaseUrl { get; set; } = string.Empty;
+    public string DataFile { get; set; } = string.Empty;
+    public string AreaFile { get; set; } = string.Empty;
+    public string FootnoteFile { get; set; } = string.Empty;
+    public string ItemFile { get; set; } = string.Empty;
+    public string PeriodFile { get; set; } = string.Empty;
+    public string SeriesFile { get; set; } = string.Empty;
+}

--- a/EconDataLens.Core/Configuration/DownloadOptions.cs
+++ b/EconDataLens.Core/Configuration/DownloadOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace EconDataLens.Core.Configuration;
+
+public class DownloadOptions
+{
+    public string DownloadDirectory { get; set; } = "downloads";
+    public bool DeleteDownloadedFiles = false;
+}

--- a/EconDataLens.Core/Interfaces/ICpiDataFileParser.cs
+++ b/EconDataLens.Core/Interfaces/ICpiDataFileParser.cs
@@ -3,10 +3,10 @@ using EconDataLens.Core.Entities.Cpi;
 
 public interface ICpiDataFileParser
 {
-    Task<IEnumerable<CpiArea>> ParseCpiAreasAsync(string filePath);
-    Task<IEnumerable<CpiData>> ParseCpiDataAsync(string filePath);
-    Task<IEnumerable<CpiFootnote>> ParseCpiFootnoteAsync(string filePath);
-    Task<IEnumerable<CpiItem>> ParseCpiItemsAsync(string filePath);
-    Task<IEnumerable<CpiPeriod>> ParseCpiPeriodsAsync(string filePath);
-    Task<IEnumerable<CpiSeries>> ParseCpiSeriesAsync(string filePath);
+    IAsyncEnumerable<CpiArea> ParseCpiAreasAsync(string? filePath, CancellationToken ct = default);
+    IAsyncEnumerable<CpiData> ParseCpiDataAsync(string? filePath);
+    IAsyncEnumerable<CpiFootnote> ParseCpiFootnoteAsync(string? filePath);
+    IAsyncEnumerable<CpiItem> ParseCpiItemsAsync(string? filePath);
+    IAsyncEnumerable<CpiPeriod> ParseCpiPeriodsAsync(string? filePath);
+    IAsyncEnumerable<CpiSeries> ParseCpiSeriesAsync(string? filePath);
 }

--- a/EconDataLens.Core/Interfaces/ICpiIngestionService.cs
+++ b/EconDataLens.Core/Interfaces/ICpiIngestionService.cs
@@ -1,0 +1,6 @@
+﻿namespace EconDataLens.Core.Interfaces;
+
+public interface ICpiIngestionService
+{
+    Task ImportAreasAsync(CancellationToken ct = default);
+}

--- a/EconDataLens.Core/Interfaces/ICpiRepository.cs
+++ b/EconDataLens.Core/Interfaces/ICpiRepository.cs
@@ -4,10 +4,10 @@ namespace EconDataLens.Core.Interfaces;
 
 public interface ICpiRepository
 {
-    Task UpsertCpiAreaAsync(IEnumerable<CpiArea> areas);
-    Task UpsertCpiDataAsync(IEnumerable<CpiData> cpiData);
-    Task UpsertCpiFootnotesAsync(IEnumerable<CpiFootnote> footnotes);
-    Task UpsertCpiItemAsync(IEnumerable<CpiItem> cpiItems);
-    Task UpsertCpiPeriodAsync(IEnumerable<CpiPeriod> periods);
-    Task UpsertCpiSeriesAsync(IEnumerable<CpiSeries> series);
+    Task UpsertCpiAreaAsync(IAsyncEnumerable<CpiArea> areas, CancellationToken ct = default);
+    Task UpsertCpiDataAsync(IAsyncEnumerable<CpiData> cpiData, CancellationToken ct = default);
+    Task UpsertCpiFootnotesAsync(IAsyncEnumerable<CpiFootnote> footnotes, CancellationToken ct = default);
+    Task UpsertCpiItemAsync(IAsyncEnumerable<CpiItem> cpiItems, CancellationToken ct = default);
+    Task UpsertCpiPeriodAsync(IAsyncEnumerable<CpiPeriod> periods, CancellationToken ct = default);
+    Task UpsertCpiSeriesAsync(IAsyncEnumerable<CpiSeries> series, CancellationToken ct = default);
 }

--- a/EconDataLens.Etl/EconDataLens.Etl.csproj
+++ b/EconDataLens.Etl/EconDataLens.Etl.csproj
@@ -27,7 +27,7 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="appsettings.example.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </None>
     </ItemGroup>
 

--- a/EconDataLens.Etl/EconDataLens.Etl.csproj
+++ b/EconDataLens.Etl/EconDataLens.Etl.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
       <ProjectReference Include="..\EconDataLens.Core\EconDataLens.Core.csproj" />
       <ProjectReference Include="..\EconDataLens.Data\EconDataLens.Data.csproj" />
+      <ProjectReference Include="..\EconDataLens.Repositories\EconDataLens.Repositories.csproj" />
       <ProjectReference Include="..\EconDataLens.Services\EconDataLens.Services.csproj" />
     </ItemGroup>
 

--- a/EconDataLens.Etl/appsettings.example.json
+++ b/EconDataLens.Etl/appsettings.example.json
@@ -2,11 +2,11 @@
   "ConnectionStrings": {
     "Postgres": "YOUR-CONNECTION-STRING-HERE"
   },
-  "DownloadSettings": {
+  "DownloadOptions": {
     "DownloadDirectory": "downloads",
     "DeleteDownloadedFiles": false
   },
-  "BLSSettings": {
+  "BlsOptions": {
     "CPI": {
       "BaseUrl": "https://download.bls.gov/pub/time.series/cu/",
       "DataFile": "cu.data.0.Current",

--- a/EconDataLens.Repositories/CpiRepository.cs
+++ b/EconDataLens.Repositories/CpiRepository.cs
@@ -1,0 +1,96 @@
+﻿using System.Data;
+using EconDataLens.Core.Configuration;
+using EconDataLens.Core.Entities.Cpi;
+using EconDataLens.Core.Interfaces;
+using EconDataLens.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace EconDataLens.Repositories;
+
+public class CpiRepository : ICpiRepository
+{
+    private readonly EconDataLensDbContext _dbContext;
+
+    public CpiRepository(EconDataLensDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task UpsertCpiAreaAsync(IAsyncEnumerable<CpiArea> areas, CancellationToken ct = default)
+    {
+        var conn = (NpgsqlConnection)_dbContext.Database.GetDbConnection();
+        if (conn.State != ConnectionState.Open) await conn.OpenAsync(ct);
+
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var tx = await conn.BeginTransactionAsync(ct);
+
+            // temp table
+            await using (var cmd = new NpgsqlCommand("""
+                                                     CREATE TEMP TABLE tmp_cpi_area (
+                                                       area_code VARCHAR(4) PRIMARY KEY, 
+                                                       area_name VARCHAR(80) NOT NULL
+                                                     ) ON COMMIT DROP;
+                                                     """, conn, tx))
+            {
+                await cmd.ExecuteNonQueryAsync(ct);
+            }
+
+            // SINGLE COPY session, streamed
+            await using (var writer = await conn.BeginBinaryImportAsync(
+                             "COPY tmp_cpi_area (area_code, area_name) FROM STDIN (FORMAT BINARY)", ct))
+            {
+                await foreach (var a in areas.WithCancellation(ct))
+                {
+                    await writer.StartRowAsync(ct);
+                    await writer.WriteAsync(a.AreaCode, NpgsqlTypes.NpgsqlDbType.Text, ct);
+                    await writer.WriteAsync(a.AreaName, NpgsqlTypes.NpgsqlDbType.Text, ct);
+                }
+                await writer.CompleteAsync(ct);
+            }
+
+            // one upsert
+            await using (var upsert = new NpgsqlCommand("""
+                                                        INSERT INTO cpi_area (area_code, area_name)
+                                                        SELECT area_code, area_name FROM tmp_cpi_area
+                                                        ON CONFLICT (area_code) DO UPDATE SET area_name = EXCLUDED.area_name;
+                                                        """, conn, tx))
+            {
+                await upsert.ExecuteNonQueryAsync(ct);
+            }
+
+            await tx.CommitAsync(ct);
+        });
+
+        _dbContext.ChangeTracker.Clear();
+    }
+
+
+    public async Task UpsertCpiDataAsync(IAsyncEnumerable<CpiData> cpiData, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task UpsertCpiFootnotesAsync(IAsyncEnumerable<CpiFootnote> footnotes, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task UpsertCpiItemAsync(IAsyncEnumerable<CpiItem> cpiItems, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task UpsertCpiPeriodAsync(IAsyncEnumerable<CpiPeriod> periods, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task UpsertCpiSeriesAsync(IAsyncEnumerable<CpiSeries> series, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EconDataLens.Repositories/EconDataLens.Repositories.csproj
+++ b/EconDataLens.Repositories/EconDataLens.Repositories.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\EconDataLens.Core\EconDataLens.Core.csproj" />
+      <ProjectReference Include="..\EconDataLens.Data\EconDataLens.Data.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/EconDataLens.Services/BasicFileDownloadService.cs
+++ b/EconDataLens.Services/BasicFileDownloadService.cs
@@ -61,12 +61,13 @@ public class BasicFileDownloadService : IFileDownloadService
         if (File.Exists(destinationPath))
         {
             File.Replace(tempPath, destinationPath, destinationPath + ".backup", ignoreMetadataErrors: true);
-            File.Delete(destinationPath);
         }
-        
-        File.Move(tempPath, destinationPath);
+        else
+        {
+            File.Move(tempPath, destinationPath);
+        }
 
-        // Cleanup stray temp if replace filed mid way
+        // Cleanup stray temp if replace filed mid-way
         if (File.Exists(tempPath)) File.Delete(tempPath);
 
         return destinationPath;

--- a/EconDataLens.Services/CpiDataFileParser.cs
+++ b/EconDataLens.Services/CpiDataFileParser.cs
@@ -1,0 +1,102 @@
+﻿using System.Text;
+
+namespace EconDataLens.Services;
+
+using EconDataLens.Core.Configuration;
+using EconDataLens.Core.Interfaces;
+using EconDataLens.Core.Entities.Cpi;
+using Microsoft.Extensions.Options;
+
+public class CpiDataFileParser : ICpiDataFileParser
+{
+    private readonly BlsOptions _blsOptions;
+    private readonly DownloadOptions _downloadOptions;
+
+    public CpiDataFileParser(IOptions<BlsOptions> blsSettings, IOptions<DownloadOptions> downloadOptions)
+    {
+        _blsOptions = blsSettings.Value;
+        _downloadOptions = downloadOptions.Value;
+    }
+    
+    public async IAsyncEnumerable<CpiArea> ParseCpiAreasAsync(string? filePath, CancellationToken ct = default)
+    {
+        // If filepath is empty, use the default
+        if (string.IsNullOrEmpty(filePath))
+        {
+            filePath = Path.Combine(_downloadOptions.DownloadDirectory, _blsOptions.Cpi.AreaFile);
+        }
+        
+        if(!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"CPI Area file not found at path: {filePath}");
+        }
+
+        await using var fs = new FileStream(
+            filePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+            bufferSize: 1 << 16, useAsync: true);
+
+        using var sr = new StreamReader(
+            fs,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 1 << 16);        
+        
+        var isHeader = true;
+
+        while (await sr.ReadLineAsync(ct) is { } line)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            if (isHeader)
+            {
+                isHeader = false;
+                continue;
+            }
+
+            var parts = line.Split('\t');
+            if (parts.Length < 2)
+            {
+                throw new FormatException($"Unexpected number of columns in CPI Area file line: {line}");
+            }
+            
+            yield return new CpiArea
+            {
+                AreaCode = parts[0],
+                AreaName = parts[1]
+            };
+        
+        }
+
+    }
+
+    public async IAsyncEnumerable<CpiData> ParseCpiDataAsync(string? filePath)
+    {
+        throw new NotImplementedException();
+        yield break;
+    }
+
+    public async IAsyncEnumerable<CpiFootnote> ParseCpiFootnoteAsync(string? filePath)
+    {
+        throw new NotImplementedException();
+        yield break;
+    }
+
+    public async IAsyncEnumerable<CpiItem> ParseCpiItemsAsync(string? filePath)
+    {
+        throw new NotImplementedException();
+        yield break;
+    }
+
+    public async IAsyncEnumerable<CpiPeriod> ParseCpiPeriodsAsync(string? filePath)
+    {
+        throw new NotImplementedException();
+        yield break;
+    }
+
+    public async IAsyncEnumerable<CpiSeries> ParseCpiSeriesAsync(string? filePath)
+    {
+        throw new NotImplementedException();
+        yield break;
+    }
+
+}

--- a/EconDataLens.Services/CpiIngestionService.cs
+++ b/EconDataLens.Services/CpiIngestionService.cs
@@ -1,0 +1,43 @@
+﻿namespace EconDataLens.Services;
+using EconDataLens.Core.Interfaces;
+using EconDataLens.Core.Configuration;
+using EconDataLens.Core.Entities.Cpi;
+using Microsoft.Extensions.Options;
+
+public class CpiIngestionService : ICpiIngestionService
+{
+    private readonly IFileDownloadService _fileDownloadService;
+    private readonly ICpiDataFileParser _parser;
+    private readonly BlsOptions _blsOptions;
+    private readonly DownloadOptions _downloadOptions;
+    private readonly ICpiRepository _cpiRepository;
+
+    public CpiIngestionService(
+        IFileDownloadService fileDownloadService,
+        ICpiDataFileParser parser,
+        IOptions<BlsOptions> blsOptions,
+        IOptions<DownloadOptions> downloadOptions,
+        ICpiRepository cpiRepository
+    )
+    {
+        _fileDownloadService = fileDownloadService;
+        _parser = parser;
+        _blsOptions = blsOptions.Value;
+        _downloadOptions = downloadOptions.Value;
+        _cpiRepository = cpiRepository;
+    }
+
+    /// <summary>
+    /// Downloads the CPI Area file from BLS, parses it, and upserts the data into the database.
+    /// Utilizes streaming to handle large files efficiently.
+    /// </summary>  
+    public async Task ImportAreasAsync(CancellationToken ct = default)
+    {
+        var url  = _blsOptions.Cpi.BaseUrl + _blsOptions.Cpi.AreaFile;
+        var path = Path.Combine(_downloadOptions.DownloadDirectory, _blsOptions.Cpi.AreaFile);
+        await _fileDownloadService.DownloadFileAsync(url, path, ct);
+        
+        await _cpiRepository.UpsertCpiAreaAsync(_parser.ParseCpiAreasAsync(path, ct), ct);
+    }
+
+}

--- a/EconDataLens.Services/EconDataLens.Services.csproj
+++ b/EconDataLens.Services/EconDataLens.Services.csproj
@@ -10,4 +10,8 @@
       <ProjectReference Include="..\EconDataLens.Core\EconDataLens.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
+    </ItemGroup>
+
 </Project>

--- a/EconDataLens.sln
+++ b/EconDataLens.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EconDataLens.Etl", "EconDat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EconDataLens.Services", "EconDataLens.Services\EconDataLens.Services.csproj", "{63490F58-898F-4375-B30C-BC296364B982}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EconDataLens.Repositories", "EconDataLens.Repositories\EconDataLens.Repositories.csproj", "{F6029051-73C2-4DA2-8DD7-63E53150D703}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{63490F58-898F-4375-B30C-BC296364B982}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63490F58-898F-4375-B30C-BC296364B982}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63490F58-898F-4375-B30C-BC296364B982}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6029051-73C2-4DA2-8DD7-63E53150D703}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6029051-73C2-4DA2-8DD7-63E53150D703}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6029051-73C2-4DA2-8DD7-63E53150D703}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6029051-73C2-4DA2-8DD7-63E53150D703}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Summary  
This PR adds end-to-end support for ingesting the **CPI Area** file from BLS into the database.  

---

### Details  
- **Configuration**  
  - Added strongly-typed configuration options (`BlsOptions`, `DownloadOptions`) to control file URLs and download locations.  

- **Streaming parser**  
  - Implemented the `area` file parser using `IAsyncEnumerable<T>` so files are streamed line by line instead of being fully loaded into memory.  
  - While the `area` file itself is small, this pattern will be critical for large CPI files (e.g., `data` files with millions of rows). This ensures consistency across all parsers and keeps memory usage predictable.  

- **CPI Ingestion Service**  
  - New service orchestrates the ingestion workflow:  
    1. Downloads the file (via `IFileDownloadService`).  
    2. Passes the file stream to the parser, yielding entities as they are parsed.  
    3. Calls the repository to upsert entities into the database.  

- **Repository layer**  
  - Added a repository project  to isolate persistence logic.  
  - Implemented CPI Area upsert using **Postgres COPY into a temp table** followed by a single `INSERT ... ON CONFLICT DO UPDATE`.  
  - This approach combines streaming input with efficient bulk writes.  

- **ETL wiring**  
  - Updated `Program.cs` in the ETL project to demonstrate the ingestion flow by downloading and importing the CPI Area file.  
  - For now, this is primarily proof-of-concept / demo code.  


